### PR TITLE
Add Ansible playbook directory

### DIFF
--- a/playbooks/roles/lfit.python-install/.coafile
+++ b/playbooks/roles/lfit.python-install/.coafile
@@ -1,0 +1,16 @@
+[all]
+ignore = .tox/**,
+    .git/**,
+    .gitignore,
+    .gitmodules,
+    .gitreview
+
+[all.Git]
+bears = GitCommitBear
+files = NONE
+ignore_length_regex = Signed-off-by,
+    Also-by,
+    Co-authored-by,
+    http://,
+    https://
+

--- a/playbooks/roles/lfit.python-install/.gitignore
+++ b/playbooks/roles/lfit.python-install/.gitignore
@@ -1,0 +1,5 @@
+.molecule/
+.tox/
+__pycache__/
+*.pyc
+

--- a/playbooks/roles/lfit.python-install/.gitreview
+++ b/playbooks/roles/lfit.python-install/.gitreview
@@ -1,0 +1,5 @@
+[gerrit]
+host=gerrit.linuxfoundation.org
+port=29418
+project=ansible/roles/python-install.git
+defaultbranch=master

--- a/playbooks/roles/lfit.python-install/.yamllint
+++ b/playbooks/roles/lfit.python-install/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/playbooks/roles/lfit.python-install/README.md
+++ b/playbooks/roles/lfit.python-install/README.md
@@ -1,0 +1,39 @@
+python-install
+==============
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+pyenv_version: Version of pyenv to install.
+python34_version: Version of Python 3.4 to install.
+python35_version: Version of Python 3.5 to install.
+python36_version: Version of Python 3.6 to install.
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+         - { role: lfit.python-install }
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Linux Foundation Release Engineering

--- a/playbooks/roles/lfit.python-install/defaults/main.yml
+++ b/playbooks/roles/lfit.python-install/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+pyenv_version: v1.2.1
+python34_version: 3.4.7
+python35_version: 3.5.4
+python36_version: 3.6.4

--- a/playbooks/roles/lfit.python-install/handlers/main.yml
+++ b/playbooks/roles/lfit.python-install/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for python-install

--- a/playbooks/roles/lfit.python-install/meta/main.yml
+++ b/playbooks/roles/lfit.python-install/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  author: Linux Foundation Release Engineering
+  description: Install Distro specific Python binaries + pyenv to install
+    multiple versions of Python.
+  company: The Linux Foundation
+  issue_tracker_url: https://jira.linuxfoundation.org
+
+  license: MIT
+
+  min_ansible_version: 1.2
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+    - name: Ubuntu
+      versions:
+        - xenial
+
+  galaxy_tags:
+    - pyenv
+    - python
+    - system
+
+dependencies: []

--- a/playbooks/roles/lfit.python-install/molecule.sh
+++ b/playbooks/roles/lfit.python-install/molecule.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SPDX-License-Identifier: EPL-1.0
+##############################################################################
+# Copyright (c) 2018 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+
+# If running in Jenkins we need to symlink the workspace so that
+# ansible can pick up the role.
+if [ ! -z "$JENKINS_URL" ]; then
+    ln -sf "$WORKSPACE" ../python-install
+fi
+
+molecule test --destroy=always

--- a/playbooks/roles/lfit.python-install/molecule/default/Dockerfile.j2
+++ b/playbooks/roles/lfit.python-install/molecule/default/Dockerfile.j2
@@ -1,0 +1,9 @@
+# Molecule managed
+
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi

--- a/playbooks/roles/lfit.python-install/molecule/default/INSTALL.rst
+++ b/playbooks/roles/lfit.python-install/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Docker Engine
+* docker-py
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install docker-py

--- a/playbooks/roles/lfit.python-install/molecule/default/create.yml
+++ b/playbooks/roles/lfit.python-install/molecule/default/create.yml
@@ -1,0 +1,59 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(true) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: false
+        log_driver: syslog
+        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+        ports: "{{ item.exposed_ports | default(omit) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/playbooks/roles/lfit.python-install/molecule/default/destroy.yml
+++ b/playbooks/roles/lfit.python-install/molecule/default/destroy.yml
@@ -1,0 +1,27 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/playbooks/roles/lfit.python-install/molecule/default/molecule.yml
+++ b/playbooks/roles/lfit.python-install/molecule/default/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: centos7
+    image: centos:7
+  - name: ubuntu1604
+    image: ubuntu:16.04
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/playbooks/roles/lfit.python-install/molecule/default/playbook.yml
+++ b/playbooks/roles/lfit.python-install/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: python-install

--- a/playbooks/roles/lfit.python-install/molecule/default/prepare.yml
+++ b/playbooks/roles/lfit.python-install/molecule/default/prepare.yml
@@ -1,0 +1,37 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Install Fedora EPEL repo
+      yum:
+        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        state: present
+      when: ansible_os_family == 'RedHat'
+      become: true
+
+    - name: Install Git
+      package: name=git state=present
+
+    - name: Install Python compile dependencies
+      yum:
+        name:
+          - bzip2-devel
+          - gcc
+          - make
+          - openssl-devel
+        state: present
+      when: ansible_os_family == 'RedHat'
+      become: true
+
+    - name: Install Python compile dependencies
+      apt:
+        name:
+          - libbz2-dev
+          - gcc
+          - make
+          - libssl-dev
+          - wget
+        state: present
+      when: ansible_distribution == 'Ubuntu'
+      become: true

--- a/playbooks/roles/lfit.python-install/molecule/default/tests/test_default.py
+++ b/playbooks/roles/lfit.python-install/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/playbooks/roles/lfit.python-install/tasks/main.yml
+++ b/playbooks/roles/lfit.python-install/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+- name: Include distro specific variables
+  include_vars: "{{item}}"
+  with_first_found:
+    - '{{ ansible_os_family }}.yml'
+
+
+- name: Install Python
+  package:
+    name: '{{ python_packages }}'
+    state: present
+  become: true
+
+
+- name: Install Python 3.6.x via pyenv
+  environment:
+    PYENV_ROOT: /opt/pyenv
+    PATH: '/opt/pyenv/bin:{{ansible_env.PATH}}'
+    PYTHON36_VERSION: '{{python36_version}}'
+  block:
+    - name: 'Install pyenv {{pyenv_version}}'
+      git:
+        repo: https://github.com/pyenv/pyenv.git
+        dest: /opt/pyenv
+        version: '{{pyenv_version}}'
+    - name: 'Install Python {{python36_version}}'
+      command: pyenv install -s "$PYTHON36_VERSION"
+    - name: Set pyenv global
+      command: pyenv global system "$PYTHON36_VERSION"
+  become: true
+
+
+- name: Install Python 3.4.x thru 3.6.x via pyenv
+  environment:
+    PYENV_ROOT: /opt/pyenv
+    PATH: '/opt/pyenv/bin:{{ansible_env.PATH}}'
+    PYTHON34_VERSION: '{{python34_version}}'
+    PYTHON35_VERSION: '{{python35_version}}'
+    PYTHON36_VERSION: '{{python36_version}}'
+  block:
+    - name: 'Install pyenv {{pyenv_version}}'
+      git:
+        repo: https://github.com/pyenv/pyenv.git
+        dest: /opt/pyenv
+        version: '{{pyenv_version}}'
+    - name: 'Install Python {{python34_version}}'
+      command: pyenv install -s "$PYTHON34_VERSION"
+      when: ansible_distribution_version != '18.04'
+    - name: 'Install Python {{python35_version}}'
+      command: pyenv install -s "$PYTHON35_VERSION"
+    - name: 'Install Python {{python36_version}}'
+      command: pyenv install -s "$PYTHON36_VERSION"
+    - name: Set pyenv global
+      command: pyenv global system "$PYTHON36_VERSION" "$PYTHON35_VERSION" "$PYTHON34_VERSION"
+  become: true
+

--- a/playbooks/roles/lfit.python-install/tests/inventory
+++ b/playbooks/roles/lfit.python-install/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/lfit.python-install/tests/test.yml
+++ b/playbooks/roles/lfit.python-install/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - python-install

--- a/playbooks/roles/lfit.python-install/tox.ini
+++ b/playbooks/roles/lfit.python-install/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+minversion = 1.6
+envlist =
+    coala,
+    molecule
+skipsdist=true
+
+[testenv:coala]
+basepython = python3
+deps =
+    coala
+    coala-bears
+commands =
+    python3 -m nltk.downloader punkt maxent_treebank_pos_tagger averaged_perceptron_tagger
+    coala --non-interactive
+
+[testenv:molecule]
+basepython = python2
+deps =
+    ansible
+    docker
+    molecule
+passenv = *
+commands =
+    ./molecule.sh

--- a/playbooks/roles/lfit.python-install/vars/Debian.yml
+++ b/playbooks/roles/lfit.python-install/vars/Debian.yml
@@ -1,0 +1,12 @@
+---
+python_packages_distro:
+  - python
+  - python-dev
+  - python-pip
+  - python-setuptools
+  - python-virtualenv
+  - python3
+  - python3-dev
+  - python3-pip
+  - python3-setuptools
+  - python3-virtualenv

--- a/playbooks/roles/lfit.python-install/vars/RedHat.yml
+++ b/playbooks/roles/lfit.python-install/vars/RedHat.yml
@@ -1,0 +1,12 @@
+---
+python_packages_distro:
+  - python
+  - python-devel
+  - python-pip
+  - python-setuptools
+  - python-virtualenv
+  - python34
+  - python34-devel
+  - python34-pip
+  - python34-setuptools
+  - python34-virtualenv

--- a/playbooks/roles/lfit.python-install/vars/main.yml
+++ b/playbooks/roles/lfit.python-install/vars/main.yml
@@ -1,0 +1,2 @@
+---
+python_packages: '{{ python_packages_distro }}'


### PR DESCRIPTION
This pull request adds a directory for Ansible playbook files, and adds an initial role to install Python. This PR provides a good starting point, but there are still other tasks/roles to be added...

Note: this adds a role that is a modified version of one from Ansible Galay, lfit/python-install (lfit = Linux Foundation IT organization)